### PR TITLE
Switching to use the link for the launch blog

### DIFF
--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -12,7 +12,7 @@ We would love to hear from you. Choose one of the below options to reach us:
 - Join us for questions, discussions, ideas and feedback over at [OpenNTF's KEEP chat](https://openntf.slack.com/archives/C0232M13WFQ). If you are not already a member of the Slack channel, you can [self-register](https://slackin.openntf.org/).
 - Discuss this documentation [here on GitHub](https://github.com/HCL-TECH-SOFTWARE/domino-keep-docs/discussions).
 - Provide feedback on the standalone tutorials on their dedicated [GitHub](https://github.com/HCL-TECH-SOFTWARE/domino-keep-tutorials).
-- Head over to the [HCL Domino Early Access Forum](https://www.hclpartnerconnect.com/dominoearlyaccessforum.nsf/allDocuments.xsp) and share your impressions.
+- Head over to the [HCL Domino Early Access Forum](https://registration.hclpartnerconnect.com/dominoearlyaccessforum.nsf) and share your impressions.
 
 ### With reference to KEEP, we would like to know
 


### PR DESCRIPTION
https://registration.hclpartnerconnect.com/dominoearlyaccessforum.nsf is what was used in the blog https://blog.hcltechsw.com/domino/announcing-the-domino-rest-api-beta-program%e2%80%af%e2%80%af/ and I have no way to check it - making the adjustment for consideration per Martin's suggestion on slack https://openntf.slack.com/archives/C0232M13WFQ/p1623422243011300
