### PR TITLE
Fixed incorrect and broken links

### DIFF
--- a/docs/howkeepworks/architecture.md
+++ b/docs/howkeepworks/architecture.md
@@ -171,11 +171,11 @@ Focusing on Maven-based builds allows us to run builds both locally and on our C
 
 To familiarize yourself with KEEP's functionality, you should read the following pages:
 
-- [KEEP Overview]({{ 'docs/design/index' | relative_url }})
-- [OpenAPI specification]({{ '/docs/extending/intro/openapi-spec' | relative_url }})
-- [The EventBus]({{ '/docs/design/eventbus' | relative_url }}) 
-- [The Barbican]({{ '/docs/design/barbican' | relative_url }})
-- [OData]({{ '/docs/tutorial/odata' | relative_url }})
+- [KEEP Overview](../index)
+- [OpenAPI specification](../extendingkeep/openapi-spec)
+- [The EventBus](eventbus.md) 
+- [The Barbican](barbican.md)
+- [OData](../tutorial/odata)
 
 
 

--- a/docs/introduction/quickstart.md
+++ b/docs/introduction/quickstart.md
@@ -28,8 +28,8 @@ You can use the built-in Swagger API, curl, or the [KEEP Admin UI](../../usingke
 ### Tutorials
 
 - Easy steps [on this site](../../tutorial)
-- A [tutorial for the skilled Notes developer](https://opensource.hcltechsw.com/keep-tutorials)
-- Similar to the previous one, but from the viewpoint of a [skilled web developer](https://opensource.hcltechsw.com/keep-tutorials)
+- A [tutorial for the skilled Notes developer](https://opensource.hcltechsw.com/domino-keep-tutorials/pages/todo/index)
+- Similar to the previous one, but from the viewpoint of a [skilled web developer](https://opensource.hcltechsw.com/domino-keep-tutorials/pages/domino-new/index#pre-requisites)
 - Explore on your own using a [Postman collection](../../references/downloads)
 
 ![OpenAPI](../assets/images/postman.png)

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -23,11 +23,11 @@ This tutorial includes multiple sections. You will see how to add a database to 
 
 ## More tutorials
 
-Additional tutorials are available as described below and also [can be found here](https://opensource.hcltechsw.com/keep-tutorials):
+Additional tutorials are available as described below and also [can be found here](https://opensource.hcltechsw.com/domino-keep-tutorials/):
 
 ### Notes and Domino Developers
 
-Follow the "Domino ToDo Database" [tutorial for Notes and Domino developers](https://opensource.hcltechsw.com/keep-tutorials). It will walk you through:
+Follow the "Domino ToDo Database" [tutorial for Notes and Domino developers](https://opensource.hcltechsw.com/domino-keep-tutorials/pages/todo/index). It will walk you through:
 
 - Using the XPages ToDo Application.
 - Viewing the ACL via Keep Postman APIs.
@@ -36,7 +36,7 @@ Follow the "Domino ToDo Database" [tutorial for Notes and Domino developers](htt
 
 ### Web Developers
 
-If you are new to Domino, see the "New Domino Database" [tutorial for web developers](https://opensource.hcltechsw.com/keep-tutorials) It will walk you through:
+If you are new to Domino, see the "New Domino Database" [tutorial for web developers](https://opensource.hcltechsw.com/domino-keep-tutorials/pages/domino-new/index#pre-requisites) It will walk you through:
 
 - Creating a new Domino database.
 - Adding forms for customers and contacts.

--- a/docs/usingkeep/keepdifference.md
+++ b/docs/usingkeep/keepdifference.md
@@ -28,7 +28,7 @@ We don't try to boil the ocean, but follow Antoine de Saint-Exupéry who proclai
 "_Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away._"
 
 - KEEP uses Forms as data schema. So access to a document is determined by the value of the form item.
-- The KEEP configuration determines what items can be read/written per form and [mode](TODO: insert mode link).
+- The KEEP configuration determines what items can be read/written per form and mode.
 - The Admin UI provides access to the field names of the form, but the API lets you specify any field name.
 - If an item doesn't exist in a document, it doesn't get returned.
 - When you have multiple forms with the same name, the AdminUI will pick one, we don't guarantee which one.


### PR DESCRIPTION
Fixed broken links on Architectural Decision page.
Corrected link to point to the exact tutorial pages and not just the HCL open source page.